### PR TITLE
Don't suppress nested exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,11 @@ python:
 
 install:
   - pip install -e .
-  - pip install docutils
+  - pip install -r requirements.txt
   - pip install codecov
-  - pip install pytest
-  - pip install pytest_aiohttp
-  - pip install pytest-runner
 
 script:
-  - python -m pytest tests
+  - pytest tests
   - python setup.py check -rm
   - if python -c "import sys; sys.exit(sys.version_info < (3,5))"; then
         python setup.py check -s;

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ CHANGES
 ------------------
 
 * Don't suppress nested exception on timeout. Exception context points
-  on cancelled line with suspended `await`
+  on cancelled line with suspended `await` (#13)
 
 1.2.1 (2017-05-02)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 CHANGES
 =======
 
+1.3.0 (2017-xx-xx)
+------------------
+
+* Don't suppress nested exception on timeout. Exception context points
+  on cancelled line with suspended `await`
+
 1.2.1 (2017-05-02)
 ------------------
 

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -43,7 +43,7 @@ class timeout:
         if exc_type is asyncio.CancelledError and self._cancelled:
             self._cancel_handler = None
             self._task = None
-            raise asyncio.TimeoutError from None
+            raise asyncio.TimeoutError
         if self._timeout is not None and self._cancel_handler is not None:
             self._cancel_handler.cancel()
             self._cancel_handler = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pytest==3.2.1
+pytest-aiohttp==0.1.3
+docutils==0.14

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,4 @@ setup(name='async-timeout',
       url='https://github.com/aio-libs/async_timeout/',
       license='Apache 2',
       packages=['async_timeout'],
-      setup_requires=[],
-      tests_require=['pytest', 'pytest_aiohttp', 'pytest-runner'],
       include_package_data=False)

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -201,7 +201,6 @@ def test_cancel_outer_coro(loop):
 def test_timeout_suppress_exception_chain(loop):
 
     with pytest.raises(asyncio.TimeoutError) as ctx:
-        with timeout(0.01, loop=loop) as t:
+        with timeout(0.01, loop=loop):
             yield from asyncio.sleep(10, loop=loop)
-            assert t._loop is loop
     assert not ctx.value.__suppress_context__

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -204,4 +204,4 @@ def test_timeout_suppress_exception_chain(loop):
         with timeout(0.01, loop=loop) as t:
             yield from asyncio.sleep(10, loop=loop)
             assert t._loop is loop
-    assert ctx.value.__suppress_context__
+    assert not ctx.value.__suppress_context__


### PR DESCRIPTION
Exception context should point on cancelled line with suspended `await`