### PR TITLE
Change behaviour for timeout <= 0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.6.1
-  - 3.6.2
 
 install:
   - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.6.1
+  - 3.6.2
 
 install:
   - pip install -e .

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,8 @@ x.x.x (xxxx-xx-xx)
 
 * Changed `timeout <= 0` behaviour
 
-  * Backward incompatibility change
-  * when timeout <= 0  `TimeoutError` raised immediately
+  * Backward incompatibility change, prior this version `0` was shortcut for `None`
+  * when timeout <= 0 `TimeoutError` raised faster
 
 1.4.0 (2017-09-09)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 CHANGES
 =======
 
+x.x.x (xxxx-xx-xx)
+------------------
+
+* Changed `timeout <= 0` behaviour
+
+  * Backward incompatibility change
+  * when timeout <= 0  `TimeoutError` raised immediately
+
 1.4.0 (2017-09-09)
 ------------------
 

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -65,9 +65,8 @@ class timeout:
                                'inside a task')
 
         if self._timeout <= 0:
-            self._task = None
-            self._cancelled = True
-            raise asyncio.TimeoutError
+            self._loop.call_soon(self._cancel_task)
+            return self
 
         self._cancel_at = self._loop.time() + self._timeout
         self._cancel_handler = self._loop.call_at(

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -64,6 +64,7 @@ class timeout:
 
         if self._timeout <= 0:
             self._task = None
+            self._cancelled = True
             raise asyncio.TimeoutError
 
         self._cancel_at = self._loop.time() + self._timeout

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -19,8 +19,6 @@ class timeout:
     loop - asyncio compatible event loop
     """
     def __init__(self, timeout, *, loop=None):
-        if timeout is not None and timeout == 0:
-            timeout = None
         self._timeout = timeout
         if loop is None:
             loop = asyncio.get_event_loop()
@@ -55,21 +53,33 @@ class timeout:
         else:
             return None
 
+    def _do_timeout(self):
+        self._cancel_handler = None
+        self._task = None
+        raise asyncio.TimeoutError
+
     def _do_enter(self):
-        if self._timeout is not None:
-            self._task = current_task(self._loop)
-            if self._task is None:
-                raise RuntimeError('Timeout context manager should be used '
-                                   'inside a task')
-            self._cancel_at = self._loop.time() + self._timeout
-            self._cancel_handler = self._loop.call_at(self._cancel_at, self._cancel_task)
+        self._task = current_task(self._loop)
+        if self._task is None:
+            raise RuntimeError('Timeout context manager should be used '
+                               'inside a task')
+
+        if self._timeout is None:
+            return self
+
+        if self._timeout <= 0:
+            self._cancel_task()
+            self._do_timeout()
+            # nothing happens afterwards `asyncio.TimeoutError` is raised
+
+        self._cancel_at = self._loop.time() + self._timeout
+        self._cancel_handler = self._loop.call_at(
+            self._cancel_at, self._cancel_task)
         return self
 
     def _do_exit(self, exc_type):
         if exc_type is asyncio.CancelledError and self._cancelled:
-            self._cancel_handler = None
-            self._task = None
-            raise asyncio.TimeoutError
+            self._do_timeout()
         if self._timeout is not None and self._cancel_handler is not None:
             self._cancel_handler.cancel()
             self._cancel_handler = None

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -54,13 +54,15 @@ class timeout:
             return None
 
     def _do_enter(self):
+        # Support Tornado 5- without timeout
+        # Details: https://github.com/python/asyncio/issues/392
+        if self._timeout is None:
+            return self
+
         self._task = current_task(self._loop)
         if self._task is None:
             raise RuntimeError('Timeout context manager should be used '
                                'inside a task')
-
-        if self._timeout is None:
-            return self
 
         if self._timeout <= 0:
             self._task = None

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -70,7 +70,6 @@ class timeout:
         if self._timeout <= 0:
             self._cancel_task()
             self._do_timeout()
-            # nothing happens afterwards `asyncio.TimeoutError` is raised
 
         self._cancel_at = self._loop.time() + self._timeout
         self._cancel_handler = self._loop.call_at(

--- a/tests/test_py35.py
+++ b/tests/test_py35.py
@@ -1,42 +1,41 @@
-import asyncio
+# import asyncio
 
-import pytest
+# import pytest
 
-from async_timeout import timeout
-
-
-async def test_async_timeout(loop):
-    with pytest.raises(asyncio.TimeoutError):
-        async with timeout(0.01, loop=loop) as cm:
-            await asyncio.sleep(10, loop=loop)
-    assert cm.expired
+# from async_timeout import timeout
 
 
-async def test_async_no_timeout(loop):
-    async with timeout(1, loop=loop) as cm:
-        await asyncio.sleep(0, loop=loop)
-    assert not cm.expired
+# async def test_async_timeout(loop):
+#     with pytest.raises(asyncio.TimeoutError):
+#         async with timeout(0.01, loop=loop) as cm:
+#             await asyncio.sleep(10, loop=loop)
+#     assert cm.expired
 
 
-async def test_async_zero(loop):
-    with pytest.raises(asyncio.TimeoutError):
-        cm = timeout(0, loop=loop)
-        async with cm:
-            await asyncio.sleep(10, loop=loop)
-    assert cm.expired
+# async def test_async_no_timeout(loop):
+#     async with timeout(1, loop=loop) as cm:
+#         await asyncio.sleep(0, loop=loop)
+#     assert not cm.expired
 
 
-async def test_async_zero_coro_not_started(loop):
-    coro_started = False
+# async def test_async_zero(loop):
+#     with pytest.raises(asyncio.TimeoutError):
+#         async with timeout(0, loop=loop) as cm:
+#             await asyncio.sleep(10, loop=loop)
+#     assert cm.expired
 
-    async def coro():
-        nonlocal coro_started
-        coro_started = True
 
-    with pytest.raises(asyncio.TimeoutError):
-        cm = timeout(0, loop=loop)
-        async with cm:
-            await coro()
+# async def test_async_zero_coro_not_started(loop):
+#     coro_started = False
 
-    assert cm.expired
-    assert coro_started is False
+#     async def coro():
+#         nonlocal coro_started
+#         coro_started = True
+
+#     with pytest.raises(asyncio.TimeoutError):
+#         async with timeout(0, loop=loop) as cm:
+#             # await asyncio.sleep(0, loop=loop)
+#             await coro()
+
+#     assert cm.expired
+#     assert coro_started is False

--- a/tests/test_py35.py
+++ b/tests/test_py35.py
@@ -34,7 +34,7 @@ async def test_async_zero_coro_not_started(loop):
 
     with pytest.raises(asyncio.TimeoutError):
         async with timeout(0, loop=loop) as cm:
-            # await asyncio.sleep(0, loop=loop)
+            await asyncio.sleep(0, loop=loop)
             await coro()
 
     assert cm.expired

--- a/tests/test_py35.py
+++ b/tests/test_py35.py
@@ -16,3 +16,27 @@ async def test_async_no_timeout(loop):
     async with timeout(1, loop=loop) as cm:
         await asyncio.sleep(0, loop=loop)
     assert not cm.expired
+
+
+async def test_async_zero(loop):
+    with pytest.raises(asyncio.TimeoutError):
+        cm = timeout(0, loop=loop)
+        async with cm:
+            await asyncio.sleep(10, loop=loop)
+    assert cm.expired
+
+
+async def test_async_zero_coro_not_started(loop):
+    coro_started = False
+
+    async def coro():
+        nonlocal coro_started
+        coro_started = True
+
+    with pytest.raises(asyncio.TimeoutError):
+        cm = timeout(0, loop=loop)
+        async with cm:
+            await coro()
+
+    assert cm.expired
+    assert coro_started is False

--- a/tests/test_py35.py
+++ b/tests/test_py35.py
@@ -1,41 +1,41 @@
-# import asyncio
+import asyncio
 
-# import pytest
+import pytest
 
-# from async_timeout import timeout
-
-
-# async def test_async_timeout(loop):
-#     with pytest.raises(asyncio.TimeoutError):
-#         async with timeout(0.01, loop=loop) as cm:
-#             await asyncio.sleep(10, loop=loop)
-#     assert cm.expired
+from async_timeout import timeout
 
 
-# async def test_async_no_timeout(loop):
-#     async with timeout(1, loop=loop) as cm:
-#         await asyncio.sleep(0, loop=loop)
-#     assert not cm.expired
+async def test_async_timeout(loop):
+    with pytest.raises(asyncio.TimeoutError):
+        async with timeout(0.01, loop=loop) as cm:
+            await asyncio.sleep(10, loop=loop)
+    assert cm.expired
 
 
-# async def test_async_zero(loop):
-#     with pytest.raises(asyncio.TimeoutError):
-#         async with timeout(0, loop=loop) as cm:
-#             await asyncio.sleep(10, loop=loop)
-#     assert cm.expired
+async def test_async_no_timeout(loop):
+    async with timeout(1, loop=loop) as cm:
+        await asyncio.sleep(0, loop=loop)
+    assert not cm.expired
 
 
-# async def test_async_zero_coro_not_started(loop):
-#     coro_started = False
+async def test_async_zero(loop):
+    with pytest.raises(asyncio.TimeoutError):
+        async with timeout(0, loop=loop) as cm:
+            await asyncio.sleep(10, loop=loop)
+    assert cm.expired
 
-#     async def coro():
-#         nonlocal coro_started
-#         coro_started = True
 
-#     with pytest.raises(asyncio.TimeoutError):
-#         async with timeout(0, loop=loop) as cm:
-#             # await asyncio.sleep(0, loop=loop)
-#             await coro()
+async def test_async_zero_coro_not_started(loop):
+    coro_started = False
 
-#     assert cm.expired
-#     assert coro_started is False
+    async def coro():
+        nonlocal coro_started
+        coro_started = True
+
+    with pytest.raises(asyncio.TimeoutError):
+        async with timeout(0, loop=loop) as cm:
+            # await asyncio.sleep(0, loop=loop)
+            await coro()
+
+    assert cm.expired
+    assert coro_started is False

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -106,9 +106,11 @@ def test_timeout_enable_zero_coro_not_started(loop):
         coro_started = True
 
     with pytest.raises(asyncio.TimeoutError):
-        with timeout(0, loop=loop):
+        cm = timeout(0, loop=loop)
+        with cm:
             yield from coro()
 
+    assert cm.expired
     assert coro_started is False
 
 

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -89,8 +89,11 @@ def test_timeout_is_none_no_task(loop):
 @asyncio.coroutine
 def test_timeout_enable_zero(loop):
     with pytest.raises(asyncio.TimeoutError):
-        with timeout(0, loop=loop):
+        cm = timeout(0, loop=loop)
+        with cm:
             yield from asyncio.sleep(0.1, loop=loop)
+
+    assert cm.expired
 
 
 @asyncio.coroutine

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -81,16 +81,14 @@ def test_timeout_disable(loop):
 
 
 def test_timeout_is_none_no_task(loop):
-    with pytest.raises(RuntimeError):
-        with timeout(None, loop=loop):
-            pass
+    with timeout(None, loop=loop) as cm:
+        assert cm._task is None
 
 
 @asyncio.coroutine
 def test_timeout_enable_zero(loop):
     with pytest.raises(asyncio.TimeoutError):
-        cm = timeout(0, loop=loop)
-        with cm:
+        with timeout(0, loop=loop) as cm:
             yield from asyncio.sleep(0.1, loop=loop)
 
     assert cm.expired
@@ -106,8 +104,8 @@ def test_timeout_enable_zero_coro_not_started(loop):
         coro_started = True
 
     with pytest.raises(asyncio.TimeoutError):
-        cm = timeout(0, loop=loop)
-        with cm:
+        with timeout(0, loop=loop) as cm:
+            yield from asyncio.sleep(0, loop=loop)
             yield from coro()
 
     assert cm.expired

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -245,6 +245,7 @@ def test_timeout_inner_other_error(loop):
             raise RuntimeError
     assert not cm.expired
 
+
 @asyncio.coroutine
 def test_timeout_remaining(loop):
     with timeout(None, loop=loop) as cm:


### PR DESCRIPTION
fix for https://github.com/aio-libs/async-timeout/issues/27

and minor fix for raising `RuntimeError` when used outside task and `timeout is None`