### PR TITLE
Drop CancelledError from the exception chain

### DIFF
--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -77,7 +77,7 @@ class timeout:
         if exc_type is asyncio.CancelledError and self._cancelled:
             self._cancel_handler = None
             self._task = None
-            raise asyncio.TimeoutError
+            raise asyncio.TimeoutError from None
         if self._timeout is not None and self._cancel_handler is not None:
             self._cancel_handler.cancel()
             self._cancel_handler = None


### PR DESCRIPTION
The CancelledError is just an implementation artifact. It should not be present in the exception chain.