### PR TITLE
Removed import causing ImportError. Refactored to accomadate change

### DIFF
--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -1,9 +1,6 @@
 import asyncio
 
 
-__version__ = '2.0.0'
-
-
 class timeout:
     """timeout context manager.
 

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,13 @@
-import pathlib
-import re
-
 from setuptools import setup
-
-here = pathlib.Path(__file__).parent
-fname = here / 'async_timeout' / '__init__.py'
-
-with fname.open() as fp:
-    try:
-        version = re.findall(r"^__version__ = '([^']+)'$", fp.read(), re.M)[0]
-    except IndexError:
-        raise RuntimeError('Unable to determine version.')
 
 
 def read(name):
-    fname = here / name
-    with fname.open() as f:
+    with open(name) as f:
         return f.read()
 
 
 setup(name='async-timeout',
-      version=version,
+      version='2.0.0',
       description=("Timeout context manager for asyncio programs"),
       long_description='\n\n'.join([read('README.rst'),
                                     read('CHANGES.rst')]),


### PR DESCRIPTION
This is causing issues in other libraries due to difference in python2 and python3. This fix allows for backwards compatibility while still maintaining functionality and cutting down on LOC.