### PR TITLE
Use version: ~> 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-version: "= 0"
+version: ~> 1.0
 dist: xenial
 sudo: required
 language: python


### PR DESCRIPTION
The version requirement `= 0` advertised as an opt-in during early development stages was an unfortunate choice, as this is going to be the opt-out once the new build config validation feature will be rolled out further. Please use `~> 1.0` instead.
