### PR TITLE
Implement timeout.at(when)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ logic around block of code or in cases when ``asyncio.wait_for()`` is
 not suitable. Also it's much faster than ``asyncio.wait_for()``
 because ``timeout`` doesn't create a new task.
 
-The ``timeout(timeout, *, loop=None)`` call returns a context manager
+The ``timeout(delay, *, loop=None)`` call returns a context manager
 that cancels a block on *timeout* expiring::
 
    async with timeout(1.5):
@@ -35,6 +35,20 @@ that cancels a block on *timeout* expiring::
    raised outside of context manager scope.
 
 *timeout* parameter could be ``None`` for skipping timeout functionality.
+
+
+Alternatively, ``timeout.at(when)`` can be used for scheduling
+at the absolute time::
+
+   loop = asyncio.get_event_loop()
+   now = loop.time()
+
+   async with timeout.at(now + 1.5):
+       await inner()
+
+
+Please note: it is not POSIX time but a time with
+undefined starting base, e.g. the time of the system power on.
 
 
 Context manager has ``.expired`` property for check if timeout happens

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -26,6 +26,15 @@ class timeout:
     """
     @classmethod
     def at(cls, when: float) -> 'timeout':
+        """Schedule the timeout at absolute time.
+
+        when arguments points on the time in the same clock system
+        as loop.time().
+
+        Please note: it is not POSIX time but a time with
+        undefined starting base, e.g. the time of the system power on.
+
+        """
         ret = cls(None)
         ret._cancel_at = when
         return ret
@@ -64,10 +73,12 @@ class timeout:
 
     @property
     def expired(self) -> bool:
+        """Is timeout expired during execution?"""
         return self._cancelled
 
     @property
     def remaining(self) -> Optional[float]:
+        """Number of seconds remaining to the timeout expiring."""
         if self._cancel_at is None:
             return None
         elif self._exited_at is None:
@@ -77,6 +88,12 @@ class timeout:
 
     @property
     def elapsed(self) -> float:
+        """Number of elapsed seconds.
+
+        The time is counted starting from entering into
+        the timeout context manager.
+
+        """
         if self._started_at is None:
             return 0.0
         elif self._exited_at is None:

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -276,3 +276,22 @@ async def test_timeout_elapsed():
             assert cm.elapsed >= 0.1
             await asyncio.sleep(0.5)
     assert cm.elapsed >= 0.1
+
+
+@pytest.mark.asyncio
+async def test_timeout_at():
+    loop = asyncio.get_event_loop()
+    with pytest.raises(asyncio.TimeoutError):
+        now = loop.time()
+        async with timeout.at(now + 0.01) as cm:
+            await asyncio.sleep(10)
+    assert cm.expired
+
+
+@pytest.mark.asyncio
+async def test_timeout_at_not_fired():
+    loop = asyncio.get_event_loop()
+    now = loop.time()
+    async with timeout.at(now + 1) as cm:
+        await asyncio.sleep(0)
+    assert not cm.expired


### PR DESCRIPTION
To cancel at the specified time (previously the delay from now was only supported).