### PR TITLE
Add possibility of using as decorator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 CHANGES
 =======
 
+Unreleased
+----------
+
+* Add posibility to use timeout as function decorator
+
 4.0.0 (2019-11-XX)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,13 @@ that cancels a block on *timeout* expiring::
 *timeout* parameter could be ``None`` for skipping timeout functionality.
 
 
+`timeout` can be also used as a decorator::
+
+    @timeout(1.5)
+    async def possibly_long_running():
+        pass
+
+
 Alternatively, ``timeout_at(when)`` can be used for scheduling
 at the absolute time::
 

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ that cancels a block on *timeout* expiring::
 *timeout* parameter could be ``None`` for skipping timeout functionality.
 
 
-`timeout` can be also used as a decorator::
+Another possibility is to use ``timeout`` as function decorator::
 
     @timeout(1.5)
     async def possibly_long_running():

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -128,6 +128,12 @@ class Timeout:
         self._do_exit(exc_type)
         return None
 
+    def __call__(self, f):
+        async def inner(*args, **kargs):
+            with self:
+                return await f(*args, **kargs)
+        return inner
+
     @property
     def expired(self) -> bool:
         """Is timeout expired during execution?"""

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -27,6 +27,26 @@ async def test_timeout():
 
 
 @pytest.mark.asyncio
+async def test_timeout_as_decorator():
+    canceled_raised = False
+
+    @timeout(0.01)
+    async def long_running_task(arg, *, karg):
+        assert arg == 1
+        assert karg == 2
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            nonlocal canceled_raised
+            canceled_raised = True
+            raise
+
+    with pytest.raises(asyncio.TimeoutError):
+        await long_running_task(1, karg=2)
+    assert canceled_raised, "CancelledError was not raised"
+
+
+@pytest.mark.asyncio
 async def test_timeout_finish_in_time():
     async def long_running_task():
         await asyncio.sleep(0.01)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

You can use timeout as function decorator.

## Are there changes in behavior for the user?

Users get additional API

## Related issue number

https://github.com/aio-libs/async-timeout/issues/141

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
