### PR TITLE
Only install typing_extensions for Python 3.5 and 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def read(name):
 
 
 install_requires = [
-    "typing_extensions>=3.6.5",
+    "typing_extensions>=3.6.5; python_version<"3.7"",
 ]
 
 


### PR DESCRIPTION
To prevent https://github.com/pypa/pip/issues/8272 downstream.

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
