### PR TITLE
Double-check timeout by checking time at exit

### DIFF
--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -189,9 +189,7 @@ class Timeout:
         self._state = _State.ENTER
 
     def _do_exit(self, exc_type: Type[BaseException]) -> None:
-        if (
-            exc_type is asyncio.CancelledError and self._state == _State.TIMEOUT
-        ) or (
+        if (exc_type is asyncio.CancelledError and self._state == _State.TIMEOUT) or (
             self.deadline is not None and self._loop.time() > self.deadline
         ):
             self._timeout_handler = None

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -189,7 +189,11 @@ class Timeout:
         self._state = _State.ENTER
 
     def _do_exit(self, exc_type: Type[BaseException]) -> None:
-        if exc_type is asyncio.CancelledError and self._state == _State.TIMEOUT:
+        if (
+            exc_type is asyncio.CancelledError and self._state == _State.TIMEOUT
+        ) or (
+            self._loop.time() > self._deadline
+        ):
             self._timeout_handler = None
             raise asyncio.TimeoutError
         # timeout is not expired

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -192,7 +192,7 @@ class Timeout:
         if (
             exc_type is asyncio.CancelledError and self._state == _State.TIMEOUT
         ) or (
-            self._loop.time() > self._deadline
+            self.deadline is not None and self._loop.time() > self.deadline
         ):
             self._timeout_handler = None
             raise asyncio.TimeoutError


### PR DESCRIPTION
## What do these changes do?

If the code being timed does not yield to the event loop, timeout seems to go unnoticed. This will at-least raise a TimeoutError when that happens.

## Are there changes in behavior for the user?

Users will see a TimeoutError when previously timeouts would have gone unnoticed.

## Related issue number

Related to samuelcolvin/arq#230

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
