### PR TITLE
Tests and partial fix for suppressing cancellations.

### DIFF
--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -198,6 +198,7 @@ class Timeout:
         return None
 
     def _on_timeout(self, task: "asyncio.Task[None]") -> None:
+        # See Issue #229 and PR #230 for details      
         if task._fut_waiter and task._fut_waiter.cancelled():  # type: ignore[attr-defined]  # noqa: E501
             return
         task.cancel()

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -198,7 +198,7 @@ class Timeout:
         return None
 
     def _on_timeout(self, task: "asyncio.Task[None]") -> None:
-        if task._fut_waiter and task._fut_waiter.cancelled():  # type: ignore[attr-defined]
+        if task._fut_waiter and task._fut_waiter.cancelled():  # type: ignore[attr-defined]  # noqa: E501
             return
         task.cancel()
         self._state = _State.TIMEOUT

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -198,7 +198,7 @@ class Timeout:
         return None
 
     def _on_timeout(self, task: "asyncio.Task[None]") -> None:
-        if task._fut_waiter and task._fut_waiter.cancelled():
+        if task._fut_waiter and task._fut_waiter.cancelled():  # type: ignore[attr-defined]
             return
         task.cancel()
         self._state = _State.TIMEOUT

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -198,6 +198,8 @@ class Timeout:
         return None
 
     def _on_timeout(self, task: "asyncio.Task[None]") -> None:
+        if task._fut_waiter and task._fut_waiter.cancelled():
+            return
         task.cancel()
         self._state = _State.TIMEOUT
 

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -358,6 +358,8 @@ async def test_race_condition_cancel_before() -> None:
     """
 
     async def test_task(deadline: float, loop: asyncio.AbstractEventLoop) -> None:
+        # We need the internal Timeout class to specify the deadline (not delay).
+        # This is needed to create the precise timing to reproduce the race condition.
         with Timeout(deadline, loop):
             await asyncio.sleep(10)
 
@@ -382,6 +384,8 @@ async def test_race_condition_cancel_after() -> None:
     """
 
     async def test_task(deadline: float, loop: asyncio.AbstractEventLoop) -> None:
+        # We need the internal Timeout class to specify the deadline (not delay).
+        # This is needed to create the precise timing to reproduce the race condition.
         with Timeout(deadline, loop):
             await asyncio.sleep(10)
 

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+import sys
 
 import pytest
 
@@ -346,15 +347,16 @@ async def test_deprecated_with() -> None:
             await asyncio.sleep(0)
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7))
 @pytest.mark.asyncio
-async def test_race_condition_cancel_before():
+async def test_race_condition_cancel_before() -> None:
     """Test race condition when cancelling before timeout.
 
     If cancel happens immediately before the timeout, then
     the timeout may overrule the cancellation, making it
     impossible to cancel some tasks.
     """
-    async def test_task(deadline, loop):
+    async def test_task(deadline: float, loop: asyncio.Loop) -> None:
         with Timeout(deadline, loop):
             await asyncio.sleep(10)
 
@@ -368,15 +370,16 @@ async def test_race_condition_cancel_before():
         await t
 
 
+@pytest.mark.skipif(sys.version_info < (3, 7))
 @pytest.mark.asyncio
-async def test_race_condition_cancel_after():
+async def test_race_condition_cancel_after() -> None:
     """Test race condition when cancelling after timeout.
 
     Similarly to the previous test, if a cancel happens
     immediately after the timeout (but before the __exit__),
     then the explicit cancel can get overruled again.
     """
-    async def test_task(deadline, loop):
+    async def test_task(deadline: float, loop: asyncio.Loop) -> None:
         with Timeout(deadline, loop):
             await asyncio.sleep(10)
 

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -347,7 +347,7 @@ async def test_deprecated_with() -> None:
             await asyncio.sleep(0)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7))
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="Not supported in 3.6")
 @pytest.mark.asyncio
 async def test_race_condition_cancel_before() -> None:
     """Test race condition when cancelling before timeout.
@@ -371,7 +371,7 @@ async def test_race_condition_cancel_before() -> None:
         await t
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7))
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="Not supported in 3.6")
 @pytest.mark.asyncio
 async def test_race_condition_cancel_after() -> None:
     """Test race condition when cancelling after timeout.

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -356,6 +356,7 @@ async def test_race_condition_cancel_before() -> None:
     the timeout may overrule the cancellation, making it
     impossible to cancel some tasks.
     """
+
     async def test_task(deadline: float, loop: asyncio.AbstractEventLoop) -> None:
         with Timeout(deadline, loop):
             await asyncio.sleep(10)
@@ -379,6 +380,7 @@ async def test_race_condition_cancel_after() -> None:
     immediately after the timeout (but before the __exit__),
     then the explicit cancel can get overruled again.
     """
+
     async def test_task(deadline: float, loop: asyncio.AbstractEventLoop) -> None:
         with Timeout(deadline, loop):
             await asyncio.sleep(10)
@@ -386,7 +388,7 @@ async def test_race_condition_cancel_after() -> None:
     loop = asyncio.get_running_loop()
     deadline = loop.time() + 1
     t = asyncio.create_task(test_task(deadline, loop))
-    loop.call_at(deadline + .000001, t.cancel)
+    loop.call_at(deadline + 0.000001, t.cancel)
     await asyncio.sleep(1.1)
     # If we get a TimeoutError, then the code is broken.
     with pytest.raises(asyncio.CancelledError):

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,6 +1,6 @@
 import asyncio
-import time
 import sys
+import time
 
 import pytest
 

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -356,7 +356,7 @@ async def test_race_condition_cancel_before() -> None:
     the timeout may overrule the cancellation, making it
     impossible to cancel some tasks.
     """
-    async def test_task(deadline: float, loop: asyncio.Loop) -> None:
+    async def test_task(deadline: float, loop: asyncio.AbstractEventLoop) -> None:
         with Timeout(deadline, loop):
             await asyncio.sleep(10)
 
@@ -379,7 +379,7 @@ async def test_race_condition_cancel_after() -> None:
     immediately after the timeout (but before the __exit__),
     then the explicit cancel can get overruled again.
     """
-    async def test_task(deadline: float, loop: asyncio.Loop) -> None:
+    async def test_task(deadline: float, loop: asyncio.AbstractEventLoop) -> None:
         with Timeout(deadline, loop):
             await asyncio.sleep(10)
 


### PR DESCRIPTION
Partially fixes #229.

I don't really see any way to get enough information to fully fix this, not really sure how best to proceed.

For an overview of why this is a serious problem, see: https://github.com/aio-libs/async-timeout/issues/229#issuecomment-908502523