### PR TITLE
Fix regression:

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 CHANGES
 =======
 
+4.0.1 (2121-11-xx)
+------------------
+
+- Fix regression:
+  1. Don't raise TimeoutError from timeout object that doesn't enter into async context
+     manager
+  2. Use call_soon() for raising TimeoutError if deadline is reached on entering into
+     async context manager
+  (#258)
+
 4.0.0 (2021-11-01)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,10 +5,13 @@ CHANGES
 ------------------
 
 - Fix regression:
+
   1. Don't raise TimeoutError from timeout object that doesn't enter into async context
      manager
+
   2. Use call_soon() for raising TimeoutError if deadline is reached on entering into
      async context manager
+
   (#258)
 
 4.0.0 (2021-11-01)

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -82,7 +82,8 @@ def test_timeout_no_loop() -> None:
 @pytest.mark.asyncio
 async def test_timeout_zero() -> None:
     with pytest.raises(asyncio.TimeoutError):
-        timeout(0)
+        async with timeout(0):
+            await asyncio.sleep(10)
 
 
 @pytest.mark.asyncio
@@ -307,10 +308,11 @@ async def test_shift_nonscheduled() -> None:
 
 
 @pytest.mark.asyncio
-async def test_shift_by_negative_expired() -> None:
+async def test_shift_negative_expired() -> None:
     async with timeout(1) as cm:
         with pytest.raises(asyncio.CancelledError):
             cm.shift(-1)
+            await asyncio.sleep(10)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
1. Don't raise TimeoutError from timeout object that doesn't enter into async context manager
2. Use call_soon() for raising TimeoutError if deadline is reached on entering into async context manager