### PR TITLE
Use stdlib typing.final in Python 3.8+

### DIFF
--- a/CHANGES/259.misc
+++ b/CHANGES/259.misc
@@ -1,0 +1,1 @@
+Use stdlib typing.final in Python 3.8+, limiting typing-extensions dependency to older Python versions.

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -5,7 +5,11 @@ import warnings
 from types import TracebackType
 from typing import Any, Optional, Type
 
-from typing_extensions import final
+
+if sys.version_info >= (3, 8):
+    from typing import final
+else:
+    from typing_extensions import final
 
 
 __version__ = "4.0.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ zip_safe = True
 include_package_data = True
 
 install_requires =
-  typing_extensions>=3.6.5
+  typing_extensions>=3.6.5; python_version < "3.8"
 
 
 [flake8]


### PR DESCRIPTION
## What do these changes do?

The "final" decorator is part of the stdlib typing module since
Python 3.8.  Use it in new enough Python versions, and fall back
to typing_extensions in older versions.

## Are there changes in behavior for the user?

Nope.

## Related issue number

n/a

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
