### PR TITLE
Tune GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   lint:
     name: Linter
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 30 # pre-commit env update can take time
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        pyver: ["3.7", "3.8", "3.9", "3.10"]
+        pyver: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
         os: [ubuntu, macos, windows]
         include:
           - pyver: pypy-3.8


### PR DESCRIPTION
1. Run tests on Python 3.11-dev
2. Increase lint job timeout, pre-commit env update can take time