### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.1.1
+        uses: dependabot/fetch-metadata@v1.3.4
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         python -m pytest tests
         python -m coverage xml
     - name: Upload coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml
         flags: unit
@@ -110,7 +110,7 @@ jobs:
       run:
         python -m build
     - name: Make Release
-      uses: aio-libs/create-release@v1.2.3
+      uses: aio-libs/create-release@v1.6.6
       with:
         changes_file: CHANGES.rst
         name: async-timeout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        pyver: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        pyver: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu, macos, windows]
         include:
           - pyver: pypy-3.9

--- a/CHANGES/333.feature
+++ b/CHANGES/333.feature
@@ -1,0 +1,1 @@
+Add support for Python 3.11.

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ classifiers =
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
+  Programming Language :: Python :: 3.11
 
 [options]
 python_requires = >=3.7


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add support for Python 3.11:

* Add Trove classifier
* Test on `3.11` instead of `3.11-dev`

Also bump GitHub Actions

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

n/a

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
