### PR TITLE
Uncancel tasks after timeout in python 3.11

### DIFF
--- a/CHANGES/362.feature
+++ b/CHANGES/362.feature
@@ -1,0 +1,1 @@
+Add uncancel call on timeout for python 3.11

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -12,6 +12,14 @@ else:
     from typing_extensions import final
 
 
+if sys.version_info >= (3, 11):
+    def _uncancel_task(task: "asyncio.Task"):
+        task.uncancel()
+else:
+    def _uncancel_task(task: "asyncio.Task"):
+        pass
+
+
 __version__ = "4.0.2"
 
 
@@ -84,7 +92,7 @@ class Timeout:
     # The purpose is to time out as soon as possible
     # without waiting for the next await expression.
 
-    __slots__ = ("_deadline", "_loop", "_state", "_timeout_handler")
+    __slots__ = ("_deadline", "_loop", "_state", "_timeout_handler", "_task")
 
     def __init__(
         self, deadline: Optional[float], loop: asyncio.AbstractEventLoop
@@ -92,6 +100,7 @@ class Timeout:
         self._loop = loop
         self._state = _State.INIT
 
+        self._task = None  # type: Optional[asyncio.Handle]
         self._timeout_handler = None  # type: Optional[asyncio.Handle]
         if deadline is None:
             self._deadline = None  # type: Optional[float]
@@ -147,6 +156,7 @@ class Timeout:
         self._reject()
 
     def _reject(self) -> None:
+        self._task = None
         if self._timeout_handler is not None:
             self._timeout_handler.cancel()
             self._timeout_handler = None
@@ -194,11 +204,11 @@ class Timeout:
         if self._timeout_handler is not None:
             self._timeout_handler.cancel()
 
-        task = asyncio.current_task()
+        self._task = asyncio.current_task()
         if deadline <= now:
-            self._timeout_handler = self._loop.call_soon(self._on_timeout, task)
+            self._timeout_handler = self._loop.call_soon(self._on_timeout)
         else:
-            self._timeout_handler = self._loop.call_at(deadline, self._on_timeout, task)
+            self._timeout_handler = self._loop.call_at(deadline, self._on_timeout)
 
     def _do_enter(self) -> None:
         if self._state != _State.INIT:
@@ -208,15 +218,17 @@ class Timeout:
 
     def _do_exit(self, exc_type: Optional[Type[BaseException]]) -> None:
         if exc_type is asyncio.CancelledError and self._state == _State.TIMEOUT:
+            _uncancel_task(self._task)
             self._timeout_handler = None
+            self._task = None
             raise asyncio.TimeoutError
         # timeout has not expired
         self._state = _State.EXIT
         self._reject()
         return None
 
-    def _on_timeout(self, task: "asyncio.Task[None]") -> None:
-        task.cancel()
+    def _on_timeout(self) -> None:
+        self._task.cancel()
         self._state = _State.TIMEOUT
         # drop the reference early
         self._timeout_handler = None

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 import time
 from functools import wraps
 from typing import Any, Callable, List, TypeVar
@@ -9,6 +10,8 @@ from async_timeout import timeout, timeout_at
 
 
 _Func = TypeVar("_Func", bound=Callable[..., Any])
+
+IS_PYTHON_311 = sys.version_info >= (3, 11)
 
 
 def log_func(func: _Func, msg: str, call_order: List[str]) -> _Func:
@@ -39,6 +42,8 @@ async def test_timeout() -> None:
             await long_running_task()
             assert t._loop is asyncio.get_event_loop()
     assert canceled_raised, "CancelledError was not raised"
+    if IS_PYTHON_311:
+        assert not asyncio.current_task().cancelling()
 
 
 @pytest.mark.asyncio
@@ -159,6 +164,8 @@ async def test_outer_coro_is_not_cancelled() -> None:
     await task
     assert has_timeout
     assert not task.cancelled()
+    if IS_PYTHON_311:
+        assert not task.cancelling()
     assert task.done()
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Python 3.11 introduced the concept of uncancelling a cancelled task.
From https://docs.python.org/3/library/asyncio-task.html#task-cancellation
> user code should not generally call [uncancel](https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.uncancel). However, in cases when suppressing [asyncio.CancelledError](https://docs.python.org/3/library/asyncio-exceptions.html#asyncio.CancelledError) is truly desired, it is necessary to also call uncancel() to completely remove the cancellation state.

This updates async-timeout to be compliant with python 3.11 when cancelling the tasks after a timeout

## Are there changes in behavior for the user?

no

## Related issue number

#362 

## Checklist

- [x] I think the code is well written
 * but happy to receive change suggestions!
- [x] Unit tests for the changes exist
- [ ] ~Documentation reflects the changes~
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
