### PR TITLE
Add support for Python 3.12-3.13 and drop EOL 3.7

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.3.4
+        uses: dependabot/fetch-metadata@v2.2.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
     timeout-minutes: 30 # pre-commit env update can take time
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
     - name: Cache PyPI
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: pip-lint-${{ hashFiles('requirements.txt') }}
         path: ~/.cache/pip
@@ -58,9 +58,9 @@ jobs:
     timeout-minutes: 15
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Python ${{ matrix.pyver }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.pyver }}
         allow-prereleases: true
@@ -69,7 +69,7 @@ jobs:
       run: |
         echo "::set-output name=dir::$(pip cache dir)"    # - name: Cache
     - name: Cache PyPI
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: pip-ci-${{ runner.os }}-${{ matrix.pyver }}-${{ hashFiles('requirements/*.txt') }}
         path: ${{ steps.pip-cache.outputs.dir }}
@@ -85,7 +85,7 @@ jobs:
         python -m pytest tests
         python -m coverage xml
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         file: ./coverage.xml
         flags: unit
@@ -99,9 +99,9 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        pyver: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        pyver: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu, macos, windows]
         include:
           - pyver: pypy-3.9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        pyver: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        pyver: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu, macos, windows]
         include:
           - pyver: pypy-3.9
@@ -63,6 +63,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.pyver }}
+        allow-prereleases: true
     - name: Get pip cache dir
       id: pip-cache
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        pyver: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        pyver: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu, macos, windows]
         include:
           - pyver: pypy-3.9

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
   rev: '23.7.0'
   hooks:
     - id: black
-      language_version: python3 # Should be a command that runs python3.6+
+      language_version: python3 # Should be a command that runs python3.8+
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: 'v4.4.0'
   hooks:
@@ -44,7 +44,7 @@ repos:
   rev: 'v3.10.1'
   hooks:
   - id: pyupgrade
-    args: ['--py36-plus']
+    args: ['--py38-plus']
 - repo: https://github.com/PyCQA/flake8
   rev: '6.1.0'
   hooks:

--- a/CHANGES/372.feature
+++ b/CHANGES/372.feature
@@ -1,0 +1,1 @@
+Add support for Python 3.12 and drop EOL 3.7.

--- a/CHANGES/372.feature
+++ b/CHANGES/372.feature
@@ -1,1 +1,1 @@
-Add support for Python 3.12 and drop EOL 3.7.
+Add support for Python 3.12-3.13 and drop EOL 3.7.

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -3,13 +3,7 @@ import enum
 import sys
 import warnings
 from types import TracebackType
-from typing import Optional, Type
-
-
-if sys.version_info >= (3, 8):
-    from typing import final
-else:
-    from typing_extensions import final
+from typing import Optional, Type, final
 
 
 if sys.version_info >= (3, 11):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pre-commit==2.21.0
 pytest==7.4.0
 pytest-asyncio==0.21.1
 pytest-cov==4.1.0
-twine==4.0.2
+twine==5.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ classifiers =
   Programming Language :: Python
   Programming Language :: Python :: 3
   Programming Language :: Python :: 3 :: Only
-  Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
@@ -36,15 +35,11 @@ classifiers =
   Programming Language :: Python :: 3.12
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 packages =
   async_timeout
 zip_safe = True
 include_package_data = True
-
-install_requires =
-  typing_extensions>=3.6.5; python_version < "3.8"
-
 
 [flake8]
 exclude = .git,.env,__pycache__,.eggs

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ classifiers =
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
+  Programming Language :: Python :: 3.12
 
 [options]
 python_requires = >=3.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ classifiers =
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
   Programming Language :: Python :: 3.12
+  Programming Language :: Python :: 3.13
 
 [options]
 python_requires = >=3.8


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The [Python 3.12 release candidate is out!](https://discuss.python.org/t/python-3-12-0-release-candidate-1-released/31137?u=hugovk) :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

See also https://dev.to/hugovk/help-test-python-312-beta-1508/

Also drop EOL Python 3.7.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

n/a
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
