### PR TITLE
Mimic asyncio.Timeout behavior

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-files = async_timeout, tests
+files = async_timeout
 check_untyped_defs = True
 follow_imports_for_stubs = True
 disallow_any_decorated = True

--- a/CHANGES/422.feature.rst
+++ b/CHANGES/422.feature.rst
@@ -1,0 +1,1 @@
+Make ``asyncio_timeout`` fully compatible with the standard ``asyncio.Timeout`` but keep backward compatibility with existing ``asyncio_timeout.Timeout`` API.

--- a/README.rst
+++ b/README.rst
@@ -17,21 +17,18 @@ asyncio-compatible timeout context manager.
 DEPRECATED
 ----------
 
-This library has effectively been upstreamed into Python 3.11+. Therefore this library
-is considered deprecated and no longer supported. We'll keep the project open in the
-unlikely case of security issues until Python 3.10 is officially unsupported.
+This library has effectively been upstreamed into Python 3.11+.
 
-To migrate a project that needs to support multiple Python versions, we suggest
-using this code (used in our other projects, such as aiohttp)::
+Therefore this library is considered deprecated and no longer actively supported.
 
-   if sys.version_info >= (3, 11):
-       import asyncio as async_timeout
-   else:
-       import async_timeout
+Version 5.0+ provides dual-mode when executed on Python 3.11+:
+``asyncio_timeout.Timeout`` is fully compatible with ``asyncio.Timeout`` *and* old
+versions of the library.
 
-Then in your dependencies, use::
+Anyway, using upstream is highly recommended. ``asyncio_timeout`` exists only for the
+sake of backward compatibility, easy supporting both old and new Python by the same
+code, and easy misgration.
 
-   async-timeout >= 4; python_version < "3.11"
 
 Usage example
 -------------

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -100,7 +100,7 @@ if sys.version_info >= (3, 11):
             super().__init__(deadline)
 
         @property
-        def expired(self) -> bool:
+        def expired(self) -> _Expired:
             # a hacky property hat can provide both roles:
             # timeout.expired()  from asyncio
             # timeout.expired    from asyncio_timeout

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -70,6 +70,7 @@ class _State(enum.Enum):
 
 
 if sys.version_info >= (3, 11):
+
     class _Expired:
         __slots__ = ("_val",)
 
@@ -87,7 +88,6 @@ if sys.version_info >= (3, 11):
 
         def __str__(self) -> str:
             return str(self._val)
-
 
     @final
     class Timeout(asyncio.Timeout):  # type: ignore[misc]

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -5,18 +5,7 @@ from types import TracebackType
 from typing import Optional, Type, final
 
 
-if sys.version_info >= (3, 11):
-
-    def _uncancel_task(task: "asyncio.Task[object]") -> None:
-        task.uncancel()
-
-else:
-
-    def _uncancel_task(task: "asyncio.Task[object]") -> None:
-        pass
-
-
-__version__ = "4.0.3"
+__version__ = "5.0.0"
 
 
 __all__ = ("timeout", "timeout_at", "Timeout")
@@ -271,7 +260,6 @@ else:
         def _do_exit(self, exc_type: Optional[Type[BaseException]]) -> None:
             if exc_type is asyncio.CancelledError and self._state == _State.TIMEOUT:
                 assert self._task is not None
-                _uncancel_task(self._task)
                 self._timeout_handler = None
                 self._task = None
                 raise asyncio.TimeoutError

--- a/async_timeout/__init__.py
+++ b/async_timeout/__init__.py
@@ -69,146 +69,220 @@ class _State(enum.Enum):
     EXIT = "EXIT"
 
 
-@final
-class Timeout:
-    # Internal class, please don't instantiate it directly
-    # Use timeout() and timeout_at() public factories instead.
-    #
-    # Implementation note: `async with timeout()` is preferred
-    # over `with timeout()`.
-    # While technically the Timeout class implementation
-    # doesn't need to be async at all,
-    # the `async with` statement explicitly points that
-    # the context manager should be used from async function context.
-    #
-    # This design allows to avoid many silly misusages.
-    #
-    # TimeoutError is raised immediately when scheduled
-    # if the deadline is passed.
-    # The purpose is to time out as soon as possible
-    # without waiting for the next await expression.
+if sys.version_info >= (3, 11):
+    class _Expired:
+        __slots__ = ("_val",)
 
-    __slots__ = ("_deadline", "_loop", "_state", "_timeout_handler", "_task")
+        def __init__(self, val: bool) -> None:
+            self._val = val
 
-    def __init__(
-        self, deadline: Optional[float], loop: asyncio.AbstractEventLoop
-    ) -> None:
-        self._loop = loop
-        self._state = _State.INIT
+        def __call__(self) -> bool:
+            return self._val
 
-        self._task: Optional["asyncio.Task[object]"] = None
-        self._timeout_handler = None  # type: Optional[asyncio.Handle]
-        if deadline is None:
-            self._deadline = None  # type: Optional[float]
-        else:
-            self.update(deadline)
+        def __bool__(self) -> bool:
+            return self._val
 
-    async def __aenter__(self) -> "Timeout":
-        self._do_enter()
-        return self
+        def __repr__(self) -> str:
+            return repr(self._val)
 
-    async def __aexit__(
-        self,
-        exc_type: Optional[Type[BaseException]],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
-    ) -> Optional[bool]:
-        self._do_exit(exc_type)
-        return None
+        def __str__(self) -> str:
+            return str(self._val)
 
-    @property
-    def expired(self) -> bool:
-        """Is timeout expired during execution?"""
-        return self._state == _State.TIMEOUT
 
-    @property
-    def deadline(self) -> Optional[float]:
-        return self._deadline
+    @final
+    class Timeout(asyncio.Timeout):  # type: ignore[misc]
+        # Supports full asyncio.Timeout API.
+        # Also provides several asyncio_timeout specific methods
+        # for backward compatibility.
+        def __init__(
+            self, deadline: Optional[float], loop: asyncio.AbstractEventLoop
+        ) -> None:
+            super().__init__(deadline)
 
-    def reject(self) -> None:
-        """Reject scheduled timeout if any."""
-        # cancel is maybe better name but
-        # task.cancel() raises CancelledError in asyncio world.
-        if self._state not in (_State.INIT, _State.ENTER):
-            raise RuntimeError(f"invalid state {self._state.value}")
-        self._reject()
+        @property
+        def expired(self) -> bool:
+            # a hacky property hat can provide both roles:
+            # timeout.expired()  from asyncio
+            # timeout.expired    from asyncio_timeout
+            return _Expired(super().expired())
 
-    def _reject(self) -> None:
-        self._task = None
-        if self._timeout_handler is not None:
-            self._timeout_handler.cancel()
-            self._timeout_handler = None
+        @property
+        def deadline(self) -> Optional[float]:
+            return self.when()
 
-    def shift(self, delay: float) -> None:
-        """Advance timeout on delay seconds.
+        def reject(self) -> None:
+            """Reject scheduled timeout if any."""
+            # cancel is maybe better name but
+            # task.cancel() raises CancelledError in asyncio world.
+            self.reschedule(None)
 
-        The delay can be negative.
+        def shift(self, delay: float) -> None:
+            """Advance timeout on delay seconds.
 
-        Raise RuntimeError if shift is called when deadline is not scheduled
-        """
-        deadline = self._deadline
-        if deadline is None:
-            raise RuntimeError("cannot shift timeout if deadline is not scheduled")
-        self.update(deadline + delay)
+            The delay can be negative.
 
-    def update(self, deadline: float) -> None:
-        """Set deadline to absolute value.
+            Raise RuntimeError if shift is called when deadline is not scheduled
+            """
+            deadline = self.when()
+            if deadline is None:
+                raise RuntimeError("cannot shift timeout if deadline is not scheduled")
+            self.reschedule(deadline + delay)
 
-        deadline argument points on the time in the same clock system
-        as loop.time().
+        def update(self, deadline: float) -> None:
+            """Set deadline to absolute value.
 
-        If new deadline is in the past the timeout is raised immediately.
+            deadline argument points on the time in the same clock system
+            as loop.time().
 
-        Please note: it is not POSIX time but a time with
-        undefined starting base, e.g. the time of the system power on.
-        """
-        if self._state == _State.EXIT:
-            raise RuntimeError("cannot reschedule after exit from context manager")
-        if self._state == _State.TIMEOUT:
-            raise RuntimeError("cannot reschedule expired timeout")
-        if self._timeout_handler is not None:
-            self._timeout_handler.cancel()
-        self._deadline = deadline
-        if self._state != _State.INIT:
+            If new deadline is in the past the timeout is raised immediately.
+
+            Please note: it is not POSIX time but a time with
+            undefined starting base, e.g. the time of the system power on.
+            """
+            self.reschedule(deadline)
+
+else:
+
+    @final
+    class Timeout:
+        # Internal class, please don't instantiate it directly
+        # Use timeout() and timeout_at() public factories instead.
+        #
+        # Implementation note: `async with timeout()` is preferred
+        # over `with timeout()`.
+        # While technically the Timeout class implementation
+        # doesn't need to be async at all,
+        # the `async with` statement explicitly points that
+        # the context manager should be used from async function context.
+        #
+        # This design allows to avoid many silly misusages.
+        #
+        # TimeoutError is raised immediately when scheduled
+        # if the deadline is passed.
+        # The purpose is to time out as soon as possible
+        # without waiting for the next await expression.
+
+        __slots__ = ("_deadline", "_loop", "_state", "_timeout_handler", "_task")
+
+        def __init__(
+            self, deadline: Optional[float], loop: asyncio.AbstractEventLoop
+        ) -> None:
+            self._loop = loop
+            self._state = _State.INIT
+
+            self._task: Optional["asyncio.Task[object]"] = None
+            self._timeout_handler = None  # type: Optional[asyncio.Handle]
+            if deadline is None:
+                self._deadline = None  # type: Optional[float]
+            else:
+                self.update(deadline)
+
+        async def __aenter__(self) -> "Timeout":
+            self._do_enter()
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: Optional[Type[BaseException]],
+            exc_val: Optional[BaseException],
+            exc_tb: Optional[TracebackType],
+        ) -> Optional[bool]:
+            self._do_exit(exc_type)
+            return None
+
+        @property
+        def expired(self) -> bool:
+            """Is timeout expired during execution?"""
+            return self._state == _State.TIMEOUT
+
+        @property
+        def deadline(self) -> Optional[float]:
+            return self._deadline
+
+        def reject(self) -> None:
+            """Reject scheduled timeout if any."""
+            # cancel is maybe better name but
+            # task.cancel() raises CancelledError in asyncio world.
+            if self._state not in (_State.INIT, _State.ENTER):
+                raise RuntimeError(f"invalid state {self._state.value}")
+            self._reject()
+
+        def _reject(self) -> None:
+            self._task = None
+            if self._timeout_handler is not None:
+                self._timeout_handler.cancel()
+                self._timeout_handler = None
+
+        def shift(self, delay: float) -> None:
+            """Advance timeout on delay seconds.
+
+            The delay can be negative.
+
+            Raise RuntimeError if shift is called when deadline is not scheduled
+            """
+            deadline = self._deadline
+            if deadline is None:
+                raise RuntimeError("cannot shift timeout if deadline is not scheduled")
+            self.update(deadline + delay)
+
+        def update(self, deadline: float) -> None:
+            """Set deadline to absolute value.
+
+            deadline argument points on the time in the same clock system
+            as loop.time().
+
+            If new deadline is in the past the timeout is raised immediately.
+
+            Please note: it is not POSIX time but a time with
+            undefined starting base, e.g. the time of the system power on.
+            """
+            if self._state == _State.EXIT:
+                raise RuntimeError("cannot reschedule after exit from context manager")
+            if self._state == _State.TIMEOUT:
+                raise RuntimeError("cannot reschedule expired timeout")
+            if self._timeout_handler is not None:
+                self._timeout_handler.cancel()
+            self._deadline = deadline
+            if self._state != _State.INIT:
+                self._reschedule()
+
+        def _reschedule(self) -> None:
+            assert self._state == _State.ENTER
+            deadline = self._deadline
+            if deadline is None:
+                return
+
+            now = self._loop.time()
+            if self._timeout_handler is not None:
+                self._timeout_handler.cancel()
+
+            self._task = asyncio.current_task()
+            if deadline <= now:
+                self._timeout_handler = self._loop.call_soon(self._on_timeout)
+            else:
+                self._timeout_handler = self._loop.call_at(deadline, self._on_timeout)
+
+        def _do_enter(self) -> None:
+            if self._state != _State.INIT:
+                raise RuntimeError(f"invalid state {self._state.value}")
+            self._state = _State.ENTER
             self._reschedule()
 
-    def _reschedule(self) -> None:
-        assert self._state == _State.ENTER
-        deadline = self._deadline
-        if deadline is None:
-            return
+        def _do_exit(self, exc_type: Optional[Type[BaseException]]) -> None:
+            if exc_type is asyncio.CancelledError and self._state == _State.TIMEOUT:
+                assert self._task is not None
+                _uncancel_task(self._task)
+                self._timeout_handler = None
+                self._task = None
+                raise asyncio.TimeoutError
+            # timeout has not expired
+            self._state = _State.EXIT
+            self._reject()
+            return None
 
-        now = self._loop.time()
-        if self._timeout_handler is not None:
-            self._timeout_handler.cancel()
-
-        self._task = asyncio.current_task()
-        if deadline <= now:
-            self._timeout_handler = self._loop.call_soon(self._on_timeout)
-        else:
-            self._timeout_handler = self._loop.call_at(deadline, self._on_timeout)
-
-    def _do_enter(self) -> None:
-        if self._state != _State.INIT:
-            raise RuntimeError(f"invalid state {self._state.value}")
-        self._state = _State.ENTER
-        self._reschedule()
-
-    def _do_exit(self, exc_type: Optional[Type[BaseException]]) -> None:
-        if exc_type is asyncio.CancelledError and self._state == _State.TIMEOUT:
+        def _on_timeout(self) -> None:
             assert self._task is not None
-            _uncancel_task(self._task)
+            self._task.cancel()
+            self._state = _State.TIMEOUT
+            # drop the reference early
             self._timeout_handler = None
-            self._task = None
-            raise asyncio.TimeoutError
-        # timeout has not expired
-        self._state = _State.EXIT
-        self._reject()
-        return None
-
-    def _on_timeout(self) -> None:
-        assert self._task is not None
-        self._task.cancel()
-        self._state = _State.TIMEOUT
-        # drop the reference early
-        self._timeout_handler = None

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -186,7 +186,9 @@ async def test_cancel_outer_coro() -> None:
     assert task.done()
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 11), reason="3.11+ has a different implementation")
+@pytest.mark.skipif(
+    sys.version_info >= (3, 11), reason="3.11+ has a different implementation"
+)
 @pytest.mark.asyncio
 async def test_timeout_suppress_exception_chain() -> None:
     with pytest.raises(asyncio.TimeoutError) as ctx:
@@ -203,7 +205,9 @@ async def test_timeout_expired() -> None:
     assert cm.expired
 
 
-@pytest.mark.skipif(sys.version_info < (3, 11), reason="Old versions don't support expired method")
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="Old versions don't support expired method"
+)
 @pytest.mark.asyncio
 async def test_timeout_expired_as_function() -> None:
     with pytest.raises(asyncio.TimeoutError):
@@ -212,7 +216,9 @@ async def test_timeout_expired_as_function() -> None:
     assert cm.expired()
 
 
-@pytest.mark.skipif(sys.version_info < (3, 11), reason="Old versions don't support expired method")
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="Old versions don't support expired method"
+)
 @pytest.mark.asyncio
 async def test_timeout_expired_methods() -> None:
     async with timeout(0.01) as cm:
@@ -275,7 +281,10 @@ async def test_reject_finished() -> None:
         await asyncio.sleep(0)
 
     assert not t.expired
-    with pytest.raises(RuntimeError, match="(invalid state EXIT)|(Cannot change state of finished Timeout)"):
+    with pytest.raises(
+        RuntimeError,
+        match="(invalid state EXIT)|(Cannot change state of finished Timeout)",
+    ):
         t.reject()
 
 
@@ -349,9 +358,12 @@ async def test_shift_by_expired() -> None:
         with pytest.raises(asyncio.CancelledError):
             await asyncio.sleep(10)
         with pytest.raises(
-                RuntimeError,
-                match=("(cannot reschedule expired timeout)|"
-                       "(Cannot change state of expiring Timeout)")):
+            RuntimeError,
+            match=(
+                "(cannot reschedule expired timeout)|"
+                "(Cannot change state of expiring Timeout)"
+            ),
+        ):
             cm.shift(10)
 
 
@@ -363,9 +375,11 @@ async def test_shift_to_expired() -> None:
         with pytest.raises(asyncio.CancelledError):
             await asyncio.sleep(10)
         with pytest.raises(
-                RuntimeError,
-                match=("(cannot reschedule expired timeout)|"
-                       "(Cannot change state of expiring Timeout)")
+            RuntimeError,
+            match=(
+                "(cannot reschedule expired timeout)|"
+                "(Cannot change state of expiring Timeout)"
+            ),
         ):
             cm.update(t0 + 10)
 
@@ -376,8 +390,10 @@ async def test_shift_by_after_cm_exit() -> None:
         await asyncio.sleep(0)
     with pytest.raises(
         RuntimeError,
-        match=("(cannot reschedule after exit from context manager)|"
-            "(Cannot change state of finished Timeout)")
+        match=(
+            "(cannot reschedule after exit from context manager)|"
+            "(Cannot change state of finished Timeout)"
+        ),
     ):
         cm.shift(1)
 


### PR DESCRIPTION
It makes `asyncio_timeout` fully compatible with the standard `asyncio.Timeout` but keeps backward compatibility with previous `asyncio_timeout.Timeout` API